### PR TITLE
feat: configure flyway database migrations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,11 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Database Migration -->
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
 
         <!-- Testing -->
         <dependency>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,11 @@ spring:
     password: legacydesk_password
     driver-class-name: org.postgresql.Driver
 
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    locations: classpath:db/migration
+
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQL10Dialect
     open-in-view: false

--- a/src/main/resources/db/migration/V1__init_schema.sql
+++ b/src/main/resources/db/migration/V1__init_schema.sql
@@ -1,0 +1,9 @@
+﻿-- Baseline system initialization migration
+CREATE TABLE system_metadata (
+                                 id VARCHAR(50) NOT NULL PRIMARY KEY,
+                                 system_version VARCHAR(20) NOT NULL,
+                                 initialized_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+INSERT INTO system_metadata (id, system_version)
+VALUES ('SYSTEM_INIT', '1.0.0');


### PR DESCRIPTION
## Summary

Integrates Flyway database migration framework with Spring Boot, establishes the `db/migration` directory structure, and adds an ANSI SQL compliant baseline schema migration script (`V1__init_schema.sql`).

## Related Issue

Closes #5

## Changes

- [ ] Authentication
- [ ] Authorization
- [ ] Customers
- [ ] Users / Employees
- [ ] Service Requests
- [ ] Workflow
- [ ] Security
- [x] Database
- [ ] Integration
- [ ] Async Processing
- [ ] Idempotency
- [x] Tests
- [ ] Documentation

## How to Test

1. Run the test suite: `.\mvnw.cmd clean test`.
2. Confirm that Flyway executes `V1__init_schema.sql` during Spring Boot startup and creates the `flyway_schema_history` table.
3. Validate that `BUILD SUCCESS` is achieved across both embedded H2 (test) and PostgreSQL (runtime).

## Checklist

- [x] Project builds successfully
- [x] Tests pass
- [x] Validation was considered
- [x] No secrets committed
- [x] Documentation updated if necessary

## Security Considerations

- [x] Access control was considered
- [x] Sensitive data exposure was considered
- [x] No sensitive information is exposed in responses
- [x] No sensitive information is exposed in logs
- [x] Input validation was considered

## Review Notes

- Configured `spring.flyway.baseline-on-migrate: true` to prevent issues with preexisting environments.
- Enforced ANSI SQL standard in migration scripts to maintain cross-compatibility between local PostgreSQL and H2 test profiles.

## Trade-offs / Decisions

Standardized all DDL scripts to pure SQL migrations executed strictly via Flyway while keeping Hibernate DDL mode set to `validate`.

## Notes

Database baseline and migration engine are now fully ready for domain schema migrations.